### PR TITLE
Icons for Google Tasks

### DIFF
--- a/brand-logos/25px_Google_Tasks.svg
+++ b/brand-logos/25px_Google_Tasks.svg
@@ -1,0 +1,4 @@
+<svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16 5H9L5 9V16L9 20H16L20 16V9L16 5Z" fill="white" stroke="black" stroke-width="2" stroke-linejoin="round"/>
+<path d="M8 12L11 15L22 4" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/brand-logos/50px_Google_Tasks.svg
+++ b/brand-logos/50px_Google_Tasks.svg
@@ -1,0 +1,4 @@
+<svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M33.5 5.5H16.5L5.5 16.5V33.5L16.5 44.5H33.5L44.5 33.5V16.5L33.5 5.5Z" fill="white" stroke="black" stroke-width="3" stroke-linejoin="round"/>
+<path d="M25.5 33.5L47.5 11.5L42.5 6.5L25.5 23.5L20.5 18.5L15.5 23.5L25.5 33.5Z" fill="white" stroke="black" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/brand-logos/80px_Google_Tasks.svg
+++ b/brand-logos/80px_Google_Tasks.svg
@@ -1,0 +1,5 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M54 8H26L8 26V54L26 72H54L72 54V26L54 8Z" fill="white" stroke="black" stroke-width="4" stroke-linejoin="round"/>
+<path d="M49 19H31L19 31V49L31 61H49L61 49V31L49 19Z" stroke="black" stroke-width="2" stroke-linejoin="round"/>
+<path d="M76 18L68 10L40 38L32 30L24 38L40 54L76 18Z" fill="white" stroke="black" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
Adds 25x25, 50x50, and 80x80 SVG files for the Google Tasks icon into the brand-logos folder.