### PR TITLE
Add gitignore for common OS files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+


### PR DESCRIPTION
Currently, the lack of a gitignore file results in .DS_Store files variously appearing (on macOS). Presumably, for Windows users, Thumbs.db would be a similar concern.
